### PR TITLE
ci: switch from GitHub Container Registry to Docker Hub

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -26,25 +26,29 @@ jobs:
       - name: Checkout the codebase
         uses: actions/checkout@v4
 
-      - name: Login to the Container registry
+      - name: Login to Docker hub
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.service.container_name }}
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.service.container_name }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
           flavor: |
             latest=true     
 
-      - name: Build and push Docker image
+      - name: Build and push Docker image(with cahche)
         uses: docker/build-push-action@v5
         with:
           context: ${{ matrix.service.context }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Update the CI workflow to build and push images to Docker Hub instead of GitHub Container Registry. This includes changing the login credentials, image repository path, and adding cache support for faster builds. The change was made to align with the organization's container registry strategy.