### PR TITLE
ci(workflows): add docker buildx setup step

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -26,6 +26,11 @@ jobs:
       - name: Checkout the codebase
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
       - name: Login to Docker hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
The Docker Buildx setup is required to enable multi-platform builds in the CI pipeline. This prepares the workflow for building images for different architectures.