### PR TITLE
ci: update docker image metadata to use vars instead of secrets

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -41,7 +41,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.service.container_name }}
+          images: ${{ vars.DOCKERHUB_USERNAME }}/${{ matrix.service.container_name }}
           tags: |
             type=ref,event=branch
             type=ref,event=tag


### PR DESCRIPTION
The change replaces secrets.DOCKERHUB_USERNAME with vars.DOCKERHUB_USERNAME in the image metadata configuration. This aligns with GitHub's recommendation to use variables (vars) over secrets when possible for improved security and maintainability.