### PR TITLE
ci(workflows): update stale issue workflow configuration

### DIFF
--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -14,6 +14,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity.'
           close-issue-message: 'Closing this issue due to inactivity. Please reopen if needed.'
-          days-before-stale: 1
-          days-before-close: 1
-          only-labels: ''  
+          days-before-stale: 21
+          days-before-close: 7
+          exempt-issue-labels: 'pinned,security'
+          enable-statistics: true
+          remove-stale-when-updated: true


### PR DESCRIPTION
- Increase days-before-stale from 1 to 21 and days-before-close from 1 to 7
- Add exempt-issue-labels for pinned and security issues
- Enable statistics and set remove-stale-when-updated to true